### PR TITLE
Add a default pull_request template for all LeastAuthority repositories

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,33 @@
+## Description
+
+**Related issue(s)**: Closes #<issue_number_goes_here>
+
+**Proposed change(s)**: <details_about_your_change_goes_here>
+
+**Additional context**: <any_other_context_about_it_goes_here>
+
+## Types of changes
+_Put an `x` in the boxes that apply_
+
+- [ ] Documentation or cosmetic update (not impacting the code)
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._
+
+_If you're unsure, don't hesitate to ask for help in a comment.
+This is simply a reminder of what reviewers are going to look at._
+
+### Always required:
+- [ ] Title of the PR is meaningful
+- [ ] Description refers to an issue discussing the matter
+- [ ] PR is appropriately sized
+### Only when relevant:
+- [ ] Tests have been added for new functionalities
+- [ ] Documentation has been updated accordingly
+- [ ] Checks in place have passed
+- [ ] Code coverage does not decrease
+
+## Thank you!


### PR DESCRIPTION
## Description

**Related issue(s)**: LeastAuthority/it-ops#142

**Proposed change(s)**: Add a generic pull request template to be used by default for all LeastAuthority repository on GitHub. The result should look like the description of this pull request.

**Additional context**: This will only impact repositories that do NOT have yet a `pull_request_template.md` file. Which means the repositories where the template exists will have to be patched to use this new default (if desired).

## Types of changes
_Put an `x` in the boxes that apply_

- [ ] Documentation or cosmetic update (not impacting the code)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

_If you're unsure, don't hesitate to ask for help in a comment.
This is simply a reminder of what reviewers are going to look at._

### Always required:
- [x] Title of the PR is meaningful
- [x] Description refers to an issue discussing the matter
- [x] PR is appropriately sized
### Only when relevant:
- [ ] Tests have been added for new functionalities
- [ ] Documentation has been updated accordingly
- [ ] Checks in place have passed
- [ ] Code coverage does not decrease

## Thank you!