### PR TITLE
Add default issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report a problem in existing functionality
+title: ''
+labels: bug
+assignees: ''
+---
+
+<!--
+BEFORE SUBMITTING: 
+1) Please search to make sure this issue has not been opened already.
+2) If this is a implementation question or trouble with your personal project, please post on StackExchange. This will get your question answered more quickly and make it easier for other devs to find the answer in the future.
+3) Delete any comment bloc such as this one.
+-->
+
+### Description
+<!-- A few words describing the bug -->
+
+### Steps to reproduce
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+### Expected behavior
+<!-- Describe what you expected to happen -->
+
+### Actual behavior
+<!-- Describe what actualy happen instead -->
+
+### Software and versions
+- Operating system(s): <!-- e.g.: OS X, Windows 11, Android 10 -->
+- Application(s): <!-- e.g.: myApp 1.2.3, Safari 6, Firefox 104 -->
+
+### Logs and screenshots
+<!-- Add logs and/or screenshots, if possible -->
+
+### Additional context
+<!-- Add any other context about the problem here -->
+<!-- E.g.: Does it happen all the time? With other user/software? -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest a new feature or an improvement of existing functionality
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+<!--
+BEFORE SUBMITTING: 
+1) Please search to make sure this feature has not been requested already
+2) If it is about something that does not work as expected, please create a bug report instead.
+3) Delete any comment bloc such as this one.
+-->
+
+### Description
+<!-- Describe the problem this feature/improvement is addressing, and the solution you'd like -->
+
+### Motivation
+<!-- Describe why it is needed: the value to a user, and who that user might be -->
+
+### Acceptance criteria
+<!-- Describe the conditions which must be met for this request to be closed -->
+
+### Additional information
+<!-- E.g.: Link to example, documentation and/or non-duplicate issue -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,23 @@
+---
+name: Task
+about: 'Anything that does not qualify as a bug report or feature request'
+title: ''
+labels: 'task'
+assignees: ''
+---
+
+<!--
+BEFORE SUBMITTING: 
+1) Please search to make sure this task has not been opened already
+2) If this is a request to access an existing service or to get help about how to use it, please consider creating the relevant issue in https://github.com/leastauthority/it-ops/issues/new/choose or contactus@leastauthority.com.
+3) Delete any comment bloc such as this one.
+-->
+
+### Description
+<!-- Brief summary of what should be done -->
+
+### Definition of Done
+<!-- How/when do we know this task is completed -->
+
+### Additional information
+<!-- E.g.: Link to example, documentation and/or non-duplicate issue -->


### PR DESCRIPTION
Refers to LeastAuthority/it-ops#142

Add default issue templates for bug report, feature request and task. Those 3 templates should only be available in the repositories owned by LeastAuthority that do NOT have ANY existing issue template already defined.

In addition, it should still be possible for a contributor of those project to create blank issues.

## Types of changes

- [x] Documentation or cosmetic update (not impacting the code)
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Title of the PR is meaningful
- [ ] Description refers to an issue discussing the matter
- [ ] PR is appropriately sized

## Thank you!